### PR TITLE
fix: require "contents: read" for private repository

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # To update pull requests by reviewdog
+      contents: read # To checkout private repository
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ jobs:
       aqua_policy_config: aqua-policy.yaml
     permissions:
       pull-requests: write
+      contents: read # To checkout private repository
 ```
 
 ## Requirements


### PR DESCRIPTION
## ⚠️ Breaking Changes

- `contents: read` is required